### PR TITLE
Build Emacs info docs in build script

### DIFF
--- a/scripts/build-emacs.sh
+++ b/scripts/build-emacs.sh
@@ -115,11 +115,19 @@ say "...compiling (jobs=$MAKE_JOBS)"
   run "make -j${MAKE_JOBS}"
 )
 
+# Build documentation (info files)
+say "...building info files"
+(
+  cd "$SRC_DIR"
+  run "make info"
+)
+
 # Install to user-local prefix
 say "...installing to ${PREFIX}"
 (
   cd "$SRC_DIR"
   run "make install"
+  run "make install-info"
 )
 
 # ymlink all installed executables (emacs, emacsclient, etags, etc.)


### PR DESCRIPTION
## Summary
- Build Emacs info manuals during the compilation step
- Install generated info files alongside the rest of Emacs

## Testing
- `emacs --batch -l tests/test-fixup-whitespace.el -f ert-run-tests-batch-and-exit` *(fails: command not found)*
- `sudo apt-get install -y emacs-nox` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ec8205c4832391bdaad4391706b7