### PR TITLE
Improve docstrings across modules

### DIFF
--- a/modules/ai-conversations.el
+++ b/modules/ai-conversations.el
@@ -33,8 +33,9 @@
   :group 'cj/ai-conversations)
 
 (defcustom cj/gptel-conversations-window-width 0.4
-  "Width for the side window when loading a conversation.
-If displaying on top/bottom, this value is treated as a height fraction."
+  "Set the side window width when loading a conversation.
+
+If displaying on the top or bottom, treat this value as a height fraction."
   :type 'number
   :group 'cj/ai-conversations)
 
@@ -45,13 +46,13 @@ If displaying on top/bottom, this value is treated as a height fraction."
   :group 'cj/ai-conversations)
 
 (defvar-local cj/gptel-autosave-enabled nil
-  "When non-nil in a GPTel conversation buffer, auto-save after each AI response.")
+  "Non-nil means auto-save after each AI response in GPTel buffers.")
 
 (defvar-local cj/gptel-autosave-filepath nil
   "File path used for auto-saving the conversation buffer.")
 
 (defcustom cj/gptel-conversations-autosave-on-send t
-  "When non-nil, auto-save the conversation immediately after `gptel-send'."
+  "Non-nil means auto-save the conversation immediately after `gptel-send'."
   :type 'boolean
   :group 'cj/ai-conversations)
 
@@ -78,7 +79,7 @@ If displaying on top/bottom, this value is treated as a height fraction."
 	(or (and (> (length trim) 0) trim) "conversation")))
 
 (defun cj/gptel--existing-topics ()
-  "Return a list of existing topic slugs (without timestamps) in conversations dir."
+  "Return topic slugs, without timestamps, present in the conversations directory."
   (when (file-exists-p cj/gptel-conversations-directory)
 	(let* ((files (directory-files cj/gptel-conversations-directory nil "\\.gptel$")))
 	  (delete-dups
@@ -88,7 +89,7 @@ If displaying on top/bottom, this value is treated as a height fraction."
 		files)))))
 
 (defun cj/gptel--latest-file-for-topic (topic-slug)
-  "Return newest saved conversation filename (not path) for TOPIC-SLUG, or nil."
+  "Return the newest saved conversation filename for TOPIC-SLUG, or nil."
   (let* ((rx (format "^%s_[0-9]\\{8\\}-[0-9]\\{6\\}\\.gptel$"
 					 (regexp-quote topic-slug)))
 		 (files (and (file-exists-p cj/gptel-conversations-directory)
@@ -96,7 +97,9 @@ If displaying on top/bottom, this value is treated as a height fraction."
 	(car (sort files #'string>))))
 
 (defun cj/gptel--timestamp-from-filename (filename)
-  "Parse and return Emacs time from FILENAME '..._YYYYMMDD-HHMMSS.gptel', or nil."
+  "Return an Emacs timestamp extracted from FILENAME, or nil.
+
+Expect FILENAME to match "..._YYYYMMDD-HHMMSS.gptel"."
   (when (string-match "_\\([0-9]\\{8\\}\\)-\\([0-9]\\{6\\}\\)\\.gptel\\'" filename)
 	(let* ((date (match-string 1 filename))
 		   (time (match-string 2 filename))
@@ -109,7 +112,7 @@ If displaying on top/bottom, this value is treated as a height fraction."
 	  (encode-time s m h D M Y))))
 
 (defun cj/gptel--conversation-candidates ()
-  "Return an alist of (DISPLAY . FILENAME) sorted per `cj/gptel-conversations-sort-order'."
+  "Return conversation candidates sorted per `cj/gptel-conversations-sort-order'."
   (unless (file-exists-p cj/gptel-conversations-directory)
 	(user-error "Conversations directory doesn't exist: %s" cj/gptel-conversations-directory))
   (let* ((files (directory-files cj/gptel-conversations-directory nil "\\.gptel$"))
@@ -137,7 +140,7 @@ If displaying on top/bottom, this value is treated as a height fraction."
     cands))
 
 (defun cj/gptel--save-buffer-to-file (buffer filepath)
-  "Save BUFFER content to FILEPATH with org visibility properties."
+  "Save BUFFER content to FILEPATH with Org visibility properties."
   (with-current-buffer buffer
 	(let ((content (buffer-string)))
 	  (with-temp-buffer
@@ -159,7 +162,8 @@ If displaying on top/bottom, this value is treated as a height fraction."
 ;;;###autoload
 (defun cj/gptel-save-conversation ()
   "Save the current AI-Assistant buffer to a .gptel file.
-Also enables autosave for subsequent AI responses to this same file."
+
+Enable autosave for subsequent AI responses to the same file."
   (interactive)
   (let ((buf (get-buffer "*AI-Assistant*")))
 	(unless buf
@@ -216,8 +220,9 @@ Also enables autosave for subsequent AI responses to this same file."
 
 ;;;###autoload
 (defun cj/gptel-load-conversation ()
-  "Load a saved GPTel conversation into the AI-Assistant buffer (chronologically sorted).
-Prompts to save the current one if present, and enables autosave."
+  "Load a saved GPTel conversation into the AI-Assistant buffer.
+
+Prompt to save the current conversation first when appropriate, then enable autosave."
   (interactive)
   (let ((ai-buffer (get-buffer-create "*AI-Assistant*")))
 	(when (and (with-current-buffer ai-buffer (> (buffer-size) 0))

--- a/modules/calibredb-epub-config.el
+++ b/modules/calibredb-epub-config.el
@@ -124,7 +124,8 @@
 
 (defun cj/nov-center-images ()
   "Center images in the current Nov buffer without modifying text.
-Uses line-prefix/wrap-prefix with a space display property aligned to a
+
+Use line-prefix and wrap-prefix with a space display property aligned to a
 computed column based on the window text area width."
   (let ((inhibit-read-only t))
 	;; Clear any prior centering prefixes first (fresh render usually makes this
@@ -183,8 +184,9 @@ computed column based on the window text area width."
 
 (defun cj/nov-jump-to-calibredb ()
   "Open CalibreDB focused on the current EPUB's book entry.
-Tries to use the Calibre book id from the parent folder name (e.g., \"Title (123)\").
-Falls back to title/author search."
+
+Try to use the Calibre book id from the parent folder name (for example,
+\"Title (123)\"). Fall back to a title or author search when no id exists."
   (interactive)
   (require 'calibredb)
   (let* ((file (cj/nov--file-path))

--- a/modules/chrono-tools.el
+++ b/modules/chrono-tools.el
@@ -48,9 +48,10 @@
 ;; ------------------------------------ TMR ------------------------------------
 
 (defun cj/tmr-select-sound-file ()
-  "Select a sound file from sounds-dir to use for tmr timers.
-Presents all audio files in the sounds directory and sets the selected
-file as tmr-sound-file. Use \\[universal-argument] to reset to default."
+  "Select a sound file from `sounds-dir' to use for tmr timers.
+
+Present all audio files in the sounds directory and set the chosen file as
+`tmr-sound-file'. Use \\[universal-argument] to reset to the default sound."
   (interactive)
   (if current-prefix-arg
 	  ;; With prefix arg, reset to default

--- a/modules/config-utilities.el
+++ b/modules/config-utilities.el
@@ -22,8 +22,9 @@
 ;; all emacs-lisp files natively if supported, or byte-compiles them if not.
 
 (defun cj/recompile-emacs-home()
-  "Delete all compiled files in Emacs home recursively before recompilation.
-Will recompile natively if supported, or byte-compiled if not."
+  "Delete all compiled files in the Emacs home before recompiling.
+
+Recompile natively when supported, otherwise fall back to byte compilation."
   (interactive)
   (let* ((native-comp-supported (boundp 'native-compile-async))
 		 (elt-dir

--- a/modules/custom-functions.el
+++ b/modules/custom-functions.el
@@ -5,6 +5,7 @@
 ;;
 ;; These are custom utility functions I use frequently.
 ;; For convenience, they are bound to a custom keymap with a prefix of "C-;".
+
 ;; Additional keymaps are created on top of this prefix to collect similar operations.
 ;;
 ;; C-; --- Custom Key Map
@@ -50,6 +51,7 @@
 ;;   C-; l r  → remove duplicate lines from the buffer, keeping the first occurrence.
 ;;   C-; l R  → remove lines containing specific text from the region or buffer.
 ;;   C-; l u  → "underline" current line: repeat a chosen character to same length on line below.
+
 ;;
 ;; C-; m --- Comment Styling & Removal
 ;;   C-; m r  → reformats selecton into a commented paragraph re-wrapping at fill column width.
@@ -79,8 +81,9 @@
 ;;; ----------------- Miscellaneous Functions And Custom Keymap -----------------
 
 (defun cj/jump-to-matching-paren ()
-  "If point is on a parenthesis, jump to it's match.
-Otherwise, complain."
+  "Jump to the matching parenthesis when point is on one.
+
+Signal a message when point is not on a parenthesis."
   (interactive)
   (cond ((looking-at "\\s\(\\|\\s\{\\|\\s\[")
 		 (forward-list))
@@ -90,6 +93,7 @@ Otherwise, complain."
 
 (defun cj/format-region-or-buffer ()
   "Reformat the region or the entire buffer.
+
 Replaces tabs with spaces, deletes trailing whitespace, and reindents the region."
   (interactive)
   (let ((start-pos (if (use-region-p) (region-beginning) (point-min)))
@@ -102,8 +106,9 @@ Replaces tabs with spaces, deletes trailing whitespace, and reindents the region
 	  (delete-trailing-whitespace))))
 
 (defun cj/count-words-buffer-or-region ()
-  "Count the number of words in buffer or region.
-Displays result as a message in the minibuffer and *Messasges* buffer."
+  "Count the number of words in the buffer or region.
+
+Display the result in the minibuffer and *Messages* buffer."
   (interactive)
   (let ((begin (point-min))
 		(end (point-max))
@@ -115,9 +120,10 @@ Displays result as a message in the minibuffer and *Messasges* buffer."
 	(message (format "There are %d words in %s." (count-words begin end) area_type))))
 
 (defun cj/replace-fraction-glyphs (start end)
-  "Replace common fraction glyphs (½) with their text format (1/2).
-Operates in the buffer or region (as identified with START and END) if selected.
-Replaces the text versions with the glyphs if function prefaced by 'C-u'."
+  "Replace common fraction glyphs between START and END.
+
+Operate on the buffer or region designated by START and END.
+Replace the text representations with glyphs when called with a \[universal-argument] prefix."
   (interactive (if (use-region-p)
                    (list (region-beginning) (region-end))
                  (list (point-min) (point-max))))
@@ -139,8 +145,9 @@ Replaces the text versions with the glyphs if function prefaced by 'C-u'."
           (replace-match (cdr r)))))))
 
 (defun cj/align-regexp-with-spaces (orig-fun &rest args)
-  "Around-advice for =align-regexp' to disable tabs during alignment.
-ORIG-FUN is the original =align-regexp'; ARGS are its arguments."
+  "Call ORIG-FUN with ARGS while temporarily disabling tabs for alignment.
+
+This advice ensures `align-regexp' uses spaces by binding `indent-tabs-mode' to nil."
   (let ((indent-tabs-mode nil))
 	(apply orig-fun args)))
 
@@ -163,6 +170,7 @@ ORIG-FUN is the original =align-regexp'; ARGS are its arguments."
     (define-key map "|" 'display-fill-column-indicator-mode)
     map)
   "The base key map for custom elisp functions holding miscellaneous functions.
+
 Other key maps extend from this key map to hold categorized functions.")
 (global-set-key (kbd "C-;") cj/custom-keymap)
 
@@ -222,6 +230,7 @@ Other key maps extend from this key map to hold categorized functions.")
 
 (defun cj/copy-whole-buffer ()
   "Copy the entire contents of the current buffer to the kill ring.
+
 Point and mark are left exactly where they were.  No transient region
 is created.  A message is displayed when done."
   (interactive)
@@ -231,14 +240,16 @@ is created.  A message is displayed when done."
 
 (defun cj/clear-to-bottom-of-buffer ()
   "Delete all text from point to the end of the current buffer.
+
 This does not save the deleted text in the kill ring."
   (interactive)
   (delete-region (point) (point-max))
   (message "Buffer contents removed to the end of the buffer."))
 
 (defun cj/clear-to-top-of-buffer ()
-  "Delete all text from point to the end of the current buffer.
-This does not save the deleted text in the kill ring."
+  "Delete all text from point to the beginning of the current buffer.
+
+Do not save the deleted text in the kill ring."
   (interactive)
   (delete-region (point) (point-min))
   (message "Buffer contents removed to the beginning of the buffer."))
@@ -249,6 +260,7 @@ This does not save the deleted text in the kill ring."
   :config
   (defun cj/print-buffer-ps ()
 	"Print the current buffer as PostScript (monochrome) to the system default printer.
+
 Sends directly to the spooler (no temp files), with no page header."
 	(interactive)
 	(let* ((spooler
@@ -289,10 +301,11 @@ Sends directly to the spooler (no temp files), with no page header."
 
 (defun cj/remove-leading-trailing-whitespace ()
   "Remove leading and trailing whitespace in a region, line, or buffer.
+
 When called interactively:
-- If a region is active, operate on the region
-- If called with C-u prefix, operate on entire buffer
-- Otherwise, operate on current line."
+- If a region is active, operate on the region.
+- If called with a \[universal-argument] prefix, operate on the entire buffer.
+- Otherwise, operate on the current line."
   (interactive)
   (let ((start (cond (current-prefix-arg (point-min))
                      ((use-region-p) (region-beginning))
@@ -309,9 +322,9 @@ When called interactively:
         (while (re-search-forward "[ \t]+$" nil t) (replace-match ""))))))
 
 (defun cj/collapse-whitespace-line-or-region ()
-  "Collapse whitespace to one space in the current line, or region if selected.
-Ensure there is exactly one space between words, and remove leading and trailing
-whitespace."
+  "Collapse whitespace to one space in the current line or active region.
+
+Ensure there is exactly one space between words and remove leading and trailing whitespace."
   (interactive)
   (save-excursion
 	(let* ((region-active (use-region-p))
@@ -333,12 +346,13 @@ whitespace."
 		  (replace-match " " nil nil))))))
 
 (defun cj/delete-blank-lines-region-or-buffer (start end)
-  "Delete all blank lines in the region between START and END.
-Blank lines contain nothing or only whitespace (spaces or tabs).
-If called with an active region, operate on that region.
-If no region is selected, prompt before operating on the whole buffer.
-Otherwise signal a user-error and do nothing. The point is restored
-to its original position after deletion."
+  "Delete blank lines between START and END.
+
+Treat blank lines as lines that contain nothing or only whitespace.
+Operate on the active region when one exists.
+Prompt before operating on the whole buffer when no region is selected.
+Signal a user error and do nothing when the user declines.
+Restore point to its original position after deletion."
   (interactive
    (if (use-region-p)
        ;; grab its boundaries if there's a region
@@ -356,8 +370,9 @@ to its original position after deletion."
   nil)
 
 (defun cj/hyphenate-whitespace-in-region (start end)
-  "Hyphenate all continuous whitespace in the region.
-START and END represent the region selected."
+  "Replace runs of whitespace between START and END with hyphens.
+
+Operate on the active region designated by START and END."
   (interactive "*r")
   (if (use-region-p)
       (save-excursion
@@ -381,7 +396,7 @@ START and END represent the region selected."
 ;;; ------------------------- Surround, Append, Prepend -------------------------
 
 (defun cj/surround-word-or-region ()
-  "Prompt for a string, insert it before and after the word at point or selected region."
+  "Surround the word at point or active region with a string read from the minibuffer."
   (interactive)
   (let ((str (read-string "Surround with: "))
         (regionp (use-region-p)))
@@ -402,7 +417,7 @@ START and END represent the region selected."
           (message "Can't insert around. No word at point and no region selected."))))))
 
 (defun cj/append-to-lines-in-region-or-buffer (str)
-  "Prompt for STR and append it to the end of each line in region or buffer."
+  "Append STR to the end of each line in the region or entire buffer."
   (interactive "sEnter string to append: ")
   (let ((start-pos (if (use-region-p)
                        (region-beginning)
@@ -418,7 +433,7 @@ START and END represent the region selected."
         (forward-line 1)))))
 
 (defun cj/prepend-to-lines-in-region-or-buffer (str)
-  "Prompt for STR and prepend it to the start of each line in region or buffer."
+  "Prepend STR to the beginning of each line in the region or entire buffer."
   (interactive "sEnter string to prepend: ")
   (let ((start-pos (if (use-region-p)
                        (region-beginning)
@@ -444,62 +459,74 @@ START and END represent the region selected."
 ;;; -------------------------- Date And Time Insertion --------------------------
 
 (defvar readable-date-time-format "%A, %B %d, %Y at %I:%M:%S %p %Z "
-  "Format of date to insert with `insert-readable-date-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-readable-date-time'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-readable-date-time ()
-  "Insert the current date and time into current buffer.
-Uses `readable-date-time-format' for the formatting the date/time."
+  "Insert the current date and time into the current buffer.
+
+Use `readable-date-time-format' for formatting."
   (interactive)
   (insert (format-time-string readable-date-time-format (current-time))))
 
 (defvar sortable-date-time-format "%Y-%m-%d %a @ %H:%M:%S %z "
-  "Format of date to insert with `insert-current-date-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-sortable-date-time'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-sortable-date-time ()
-  "Insert the current date and time into current buffer.
-Uses `sortable-date-time-format' for the formatting the date/time."
+  "Insert the current date and time into the current buffer.
+
+Use `sortable-date-time-format' for formatting."
   (interactive)
   (insert (format-time-string sortable-date-time-format (current-time))))
 
 (defvar sortable-time-format "%I:%M:%S %p %Z "
-  "Time format to insert with `insert-current-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-sortable-time'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-sortable-time ()
-  "Insert the current time into current buffer.
-Uses `sortable-time-format' for the formatting the date/time."
+  "Insert the current time into the current buffer.
+
+Use `sortable-time-format' for formatting."
   (interactive)
   (insert (format-time-string sortable-time-format (current-time))))
 
 (defvar readable-time-format  "%-I:%M %p "
-  "Time format to insert with `insert-readable-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-readable-time'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-readable-time ()
-  "Insert the current time into current buffer.
-Uses `readable-time-format' for the formatting the date/time."
+  "Insert the current time into the current buffer.
+
+Use `readable-time-format' for formatting."
   (interactive)
   (insert (format-time-string readable-time-format (current-time))))
 
 (defvar sortable-date-format "%Y-%m-%d %a"
-  "Time format to insert with `insert-current-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-sortable-date'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-sortable-date ()
-  "Insert the current time into current buffer.
-Uses `sortable-time-format' for the formatting the date/time."
+  "Insert the current date into the current buffer.
+
+Use `sortable-date-format' for formatting."
   (interactive)
   (insert (format-time-string sortable-date-format (current-time))))
 
 (defvar readable-date-format "%A, %B %d, %Y"
-  "Time format to insert with `insert-readable-time' func.
-See help of `format-time-string' for possible replacements")
+  "Format string used by `cj/insert-readable-date'.
+
+See `format-time-string' for possible replacements.")
 
 (defun cj/insert-readable-date ()
-  "Insert the current date into current buffer.
-Uses `readable-time-format' for the formatting the date/time."
+  "Insert the current date into the current buffer.
+
+Use `readable-date-format' for formatting."
   (interactive)
   (insert (format-time-string readable-date-format (current-time))))
 
@@ -518,7 +545,7 @@ Uses `readable-time-format' for the formatting the date/time."
 
 
 (defun cj/join-line-or-region ()
-  "Apply 'join-line' over the marked region or join with previous line."
+  "Join lines in the active region or join the current line with the previous one."
   (interactive)
   (if (use-region-p)
 	  (let ((beg (region-beginning))
@@ -534,15 +561,16 @@ Uses `readable-time-format' for the formatting the date/time."
 	(newline)))
 
 (defun cj/join-paragraph ()
-  "Mark all text in a paragraph then run cj/join-line-or-region."
+  "Join all lines in the current paragraph using `cj/join-line-or-region'."
   (interactive)
   (er/mark-paragraph) ;; from package expand region
   (cj/join-line-or-region (region-beginning)(region-end))
   (forward-line))
 
 (defun cj/duplicate-line-or-region (&optional comment)
-  "Duplicate the line or region below.
-Comment the duplicated line if prefix argument COMMENT is passed."
+  "Duplicate the current line or active region below.
+
+Comment the duplicated text when optional COMMENT is non-nil."
   (interactive "P")
   (let* ((b (if (region-active-p) (region-beginning) (line-beginning-position)))
          (e (if (region-active-p) (region-end) (line-end-position)))
@@ -558,8 +586,9 @@ Comment the duplicated line if prefix argument COMMENT is passed."
 		  (comment-region (line-beginning-position) (line-end-position)))))))
 
 (defun cj/remove-duplicate-lines-region-or-buffer ()
-  "Find duplicate lines in region or buffer keeping the first occurrence.
-If a region is selected, operate on the region. Otherwise, operate on the whole buffer."
+  "Remove duplicate lines in the region or buffer, keeping the first occurrence.
+
+Operate on the active region when one exists; otherwise operate on the whole buffer."
   (interactive)
   (let ((start (if (use-region-p) (region-beginning) (point-min)))
         (end (if (use-region-p) (region-end) (point-max))))
@@ -574,6 +603,7 @@ If a region is selected, operate on the region. Otherwise, operate on the whole 
 
 (defun cj/remove-lines-containing (text)
   "Remove all lines containing TEXT.
+
 If region is active, operate only on the region, otherwise on entire buffer.
 The operation is undoable."
   (interactive "sRemove lines containing: ")
@@ -601,6 +631,7 @@ The operation is undoable."
 
 (defun cj/underscore-line ()
   "Underline the current line by inserting a row of characters below it.
+
 If the line is empty or contains only whitespace, abort with a message."
   (interactive)
   (let ((line (buffer-substring-no-properties
@@ -631,7 +662,7 @@ If the line is empty or contains only whitespace, abort with a message."
 ;;; ---------------------------------- Comments ---------------------------------
 
 (defun cj/comment-reformat ()
-  "Reformats commented text into a single paragraph."
+  "Reformat commented text into a single paragraph."
   (interactive)
 
   (if mark-active
@@ -648,9 +679,11 @@ If the line is empty or contains only whitespace, abort with a message."
 
 (defun cj/comment-centered (&optional comment-char)
   "Insert comment text centered around the COMMENT-CHAR character.
-Will default to the '#' character if called with no arguments. Uses the value of
-fill-column or 80 (whichever is less) to calculate the comment length. Will
-begin and end the line with the appropriate comment symbols based on programming mode."
+
+Default to the "#" character when COMMENT-CHAR is nil.
+
+Use the lesser of `fill-column' or 80 to calculate the comment length.
+Begin and end the line with the appropriate comment symbols for the current mode."
   (interactive)
   (if (not (char-or-string-p comment-char))
 	  (setq comment-char "#"))
@@ -692,6 +725,7 @@ begin and end the line with the appropriate comment symbols based on programming
 
 (defun cj/comment-box ()
   "Insert a comment box around text that the user inputs.
+
 The box extends to the fill column, centers the text, and uses the current
 mode's comment syntax at both the beginning and end of each line. The box
 respects the current indentation level and avoids trailing whitespace."
@@ -784,9 +818,10 @@ respects the current indentation level and avoids trailing whitespace."
 ;;; ---------------------- Ordering And Sorting Operations ----------------------
 
 (defun cj/arrayify (start end quote)
-  "Turn unquoted text on newlines into quoted comma-separated strings.
-START and END indicate the region selected.
-QUOTE is the characters used for quotations (i.e, \=' or \")"
+  "Convert lines between START and END into quoted, comma-separated strings.
+
+START and END identify the active region.
+QUOTE specifies the quotation characters to surround each element."
   (interactive "r\nMQuotation character to use for array element: ")
   (let ((insertion
 		 (mapconcat
@@ -796,8 +831,9 @@ QUOTE is the characters used for quotations (i.e, \=' or \")"
 	(insert insertion)))
 
 (defun cj/unarrayify (start end)
-  "Turn quoted comma-separated strings into unquoted text on newlines.
-START and END indicate the region selected."
+  "Convert quoted, comma-separated strings between START and END into separate lines.
+
+START and END identify the active region."
   (interactive "r")
   (let ((insertion
 		 (mapconcat
@@ -807,8 +843,9 @@ START and END indicate the region selected."
 	(insert insertion)))
 
 (defun cj/alphabetize-region ()
-  "Alphabetize strings (words/tokens) in region replacing the original region.
-The result will be comma separated."
+  "Alphabetize words in the active region and replace the original text.
+
+Produce a comma-separated list as the result."
   (interactive)
   (unless (use-region-p)
     (user-error "No region selected"))
@@ -824,7 +861,7 @@ The result will be comma separated."
 				", "))))
 
 (defun cj/comma-separated-text-to-lines ()
-  "Breaks up text between commas in a region and places each text on its own line."
+  "Break up comma-separated text in the active region so each item is on its own line."
   (interactive)
   (if (not (region-active-p))
 	  (error "No region selected"))
@@ -858,6 +895,7 @@ The result will be comma separated."
 
 (defun cj/title-case-region ()
   "Capitalize the region in title case format.
+
 Title case is a capitalization convention where major words
 are capitalized,and most minor words are lowercase.  Nouns,
 verbs (including linking verbs), adjectives, adverbs,pronouns,
@@ -874,6 +912,7 @@ and all articles are considered minor words."
 		(chars-skip-reset '(?: ?! ??))
 		;; Don't capitalize characters directly after these. e.g.
 		;; "Foo-bar" or "Foo\bar" or "Foo's".
+
 		(chars-separator '(?\\ ?- ?' ?.))
 
 		(word-chars "[:alnum:]")

--- a/modules/dirvish-config.el
+++ b/modules/dirvish-config.el
@@ -73,6 +73,7 @@
 
 (defun cj/dirvish-open-file-manager-here ()
   "Open system's default file manager in the current dired/dirvish directory.
+
 Always opens the file manager in the directory currently being displayed,
 regardless of what file or subdirectory the point is on."
   (interactive)
@@ -287,6 +288,7 @@ regardless of what file or subdirectory the point is on."
 
 (defun cj/dired-create-playlist-from-marked ()
   "Create an .m3u playlist file from marked files in Dired (or Dirvish).
+
 Filters for audio files, prompts for the playlist name, and saves the resulting
 .m3u in the directory specified by =music-dir=. Interactive use only."
   (interactive)

--- a/modules/dwim-shell-config.el
+++ b/modules/dwim-shell-config.el
@@ -233,6 +233,7 @@
 
   (defun cj/dwim-shell-commands-extract-archive-smartly ()
 	"Unzip all marked archives (of any kind) using =atool'.
+
 If there's only one file, unzip it to current directory.
 Otherwise, unzip it to an appropriately named subdirectory "
 	(interactive)
@@ -269,6 +270,7 @@ Otherwise, unzip it to an appropriately named subdirectory "
 
   (defun cj/dwim-shell-commands-document-to-pdf ()
 	"Convert document(s) to pdf (via latex).
+
 Supports docx, odt, and other pandoc-compatible formats."
 	(interactive)
 	(dwim-shell-command-on-marked-files
@@ -689,6 +691,7 @@ Supports docx, odt, and other pandoc-compatible formats."
 
   (defun cj/dwim-shell-commands-kill-gpg-agent ()
 	"Kill (thus restart) gpg agent.
+
 Useful for when you get this error:
 gpg: public key decryption failed: No pinentry
 gpg: decryption failed: No pinentry"

--- a/modules/elfeed-config.el
+++ b/modules/elfeed-config.el
@@ -46,20 +46,21 @@
 					  :name "IINA"
 					  :needs-stream-url t
 					  :yt-dlp-formats ("best[height<=1080]" "22" "best"))))
-  "Alist of media players and their configurations.
-Each entry is (SYMBOL . PLIST) where PLIST contains:
-  :command - the executable name
-  :args - additional arguments (string or nil)
-  :name - human-readable name
-  :needs-stream-url - if t, extract stream URL with yt-dlp before playing
-  :yt-dlp-formats - list of format strings to try in order (nil for direct play)"
+  "Define media players and their configurations for Elfeed integration.
+
+Each entry is (SYMBOL . PLIST). The PLIST accepts the keys :command for the
+executable name, :args for optional arguments, :name for a human-readable
+label, :needs-stream-url for a boolean flag indicating whether to extract a
+stream URL with `yt-dlp', and :yt-dlp-formats for a prioritized list of format
+strings."
   :type '(alist :key-type symbol
 				:value-type (plist :key-type keyword
 								   :value-type sexp))
   :group 'elfeed)
 
 (defcustom cj/default-media-player 'mpv
-  "Default media player to use for elfeed videos.
+  "Choose the default media player to use for Elfeed videos.
+
 Should be a key from `cj/media-players'."
   :type 'symbol
   :group 'elfeed)
@@ -175,6 +176,7 @@ Should be a key from `cj/media-players'."
 
 (defun cj/extract-stream-url (url format)
   "Extract the direct stream URL from URL using yt-dlp with FORMAT.
+
 Returns the stream URL or nil on failure."
   (unless (executable-find "yt-dlp")
 	(error "The program yt-dlp is not installed or not in PATH"))
@@ -209,6 +211,7 @@ Returns the stream URL or nil on failure."
 
 (defun cj/elfeed-process-entries (action-fn action-name &optional skip-error-handling)
   "Process selected Elfeed entries with ACTION-FN.
+
 ACTION-NAME is used for error messages. Marks entries as read and
 advances to the next line. If SKIP-ERROR-HANDLING is non-nil, errors
 are not caught (useful for actions that handle their own errors)."
@@ -234,6 +237,7 @@ are not caught (useful for actions that handle their own errors)."
 
 (defun cj/elfeed-eww-open ()
   "Opens the links of the currently selected Elfeed entries with EWW.
+
 Applies cj/eww-readable-nonce hook after EWW rendering."
   (interactive)
   (cj/elfeed-process-entries
@@ -352,6 +356,7 @@ Applies cj/eww-readable-nonce hook after EWW rendering."
 
 (defun cj/play-with-video-player ()
   "Plays the selected Elfeed entries' links with the configured media player.
+
 Note: Function name kept for backwards compatibility."
   (interactive)
   (cj/elfeed-process-entries #'cj/media-play-it
@@ -362,6 +367,7 @@ Note: Function name kept for backwards compatibility."
 
 (defun cj/youtube-to-elfeed-feed-format (url type)
   "Convert YouTube URL to elfeed-feeds format.
+
 TYPE should be either \='channel or \='playlist."
   (let ((id nil)
         (title nil)

--- a/modules/erc-config.el
+++ b/modules/erc-config.el
@@ -114,6 +114,7 @@
 
 (defun cj/erc-join-channel-with-completion ()
   "Join a channel on the current server.
+
 If not in an active ERC server buffer, reconnect first."
   (interactive)
   (unless (cj/erc-server-buffer-active-p)
@@ -244,6 +245,7 @@ If not in an active ERC server buffer, reconnect first."
 
 (defun cj/erc-notify-on-mention (match-type nick message)
   "Display a notification when MATCH-TYPE is 'current-nick.
+
 NICK is the sender and MESSAGE is the message text."
   (when (and (eq match-type 'current-nick)
 			 (not (string= nick (erc-current-nick)))

--- a/modules/external-open.el
+++ b/modules/external-open.el
@@ -110,6 +110,7 @@
 
 (defun cj/identify-external-open-command ()
   "Return the OS-default \"open\" command for this host.
+
 Signals an error if the host is unsupported."
   (cond
    ((env-linux-p)   "xdg-open")
@@ -119,6 +120,7 @@ Signals an error if the host is unsupported."
 
 (defun cj/xdg-open (&optional filename)
   "Open FILENAME (or the file at point) with the OS default handler.
+
 Logs output and exit code to buffer *external-open.log*."
   (interactive)
   (let* ((file  (expand-file-name (or filename (dired-file-name-at-point))))
@@ -141,6 +143,7 @@ Logs output and exit code to buffer *external-open.log*."
 
 (defun cj/find-file-auto (orig-fun &rest args)
   "If file has an extension in `default-open-extensions', open externally.
+
 Else call ORIG-FUN with ARGS."
   (let* ((file (car args))
 		 (case-fold-search t))

--- a/modules/flycheck-config.el
+++ b/modules/flycheck-config.el
@@ -18,6 +18,7 @@
 ;; Note: I do use proselint quite a bit in emails and org-mode files. However, some
 ;; org-files can be large and running proselint on them will slow Emacs to a crawl.
 ;; Therefore, hitting "C-; ?" also runs cj/flycheck-prose-on-demand if in an org buffer.
+
 ;;
 ;; The cj/flycheck-prose-on-demand function:
 ;; - Turns on flycheck for the local buffer
@@ -75,6 +76,7 @@
 
   (defun cj/flycheck-list-errors ()
     "Display flycheck's error list and switch to its buffer.
+
 Runs flycheck-prose-on-demand if in an org-buffer."
     (interactive)
     (when (derived-mode-p 'org-mode)

--- a/modules/flyspell-and-abbrev.el
+++ b/modules/flyspell-and-abbrev.el
@@ -103,6 +103,7 @@
 
 ;; (defun flyspell-toggle ()
 ;;   "Turn Flyspell on if it is off, or off if it is on.
+
 ;; When turning on,it uses `flyspell-on-for-buffer-type' so code-vs-text is
 ;; handled appropriately."
 ;;   (interactive)
@@ -121,6 +122,7 @@
 
 ;; (defun flyspell-on-for-buffer-type ()
 ;;   "Enable Flyspell for the major mode and check the current buffer.
+
 ;; If flyspell is already enabled, do nothing.  If the mode is derived from
 ;; `prog-mode', enable `flyspell-prog-mode' so only strings and comments get
 ;; checked.  If the buffer is text based `flyspell-mode' is enabled to check
@@ -167,6 +169,7 @@
 
 (defun cj/flyspell-goto-previous-misspelling (position)
   "Go to the first misspelled word before the given POSITION.
+
 Return the misspelled word if found or nil if not. Leave the point at the
 beginning of the misspelled word. Setting the hook on pre-command ensures that
 any started Flyspell corrections complete before running other commands in the
@@ -184,6 +187,7 @@ buffer."
 
 (defun cj/flyspell-then-abbrev (p)
   "Call \='flyspell-correct-at-point\=' and create abbrev for future corrections.
+
 The abbrev is created in the local dictionary unless the prefix P
 argument is provided, when it's created in the global dictionary."
   (interactive "P")

--- a/modules/font-config.el
+++ b/modules/font-config.el
@@ -113,6 +113,7 @@
 
   (defun cj/apply-font-settings-to-frame (&optional frame)
 	"Apply font settings to FRAME if not already configured.
+
 If FRAME is nil, uses the selected frame."
 	(let ((target-frame (or frame (selected-frame))))
 	  (unless (member target-frame cj/fontaine-configured-frames)

--- a/modules/help-config.el
+++ b/modules/help-config.el
@@ -46,6 +46,7 @@
 
   (defun cj/open-with-info-mode ()
 	"Open the current buffer's file in Info mode if it's a valid info file.
+
 Preserves any unsaved changes and checks if the file exists."
 	(interactive)
 	(let ((file-name (buffer-file-name)))

--- a/modules/help-utils.el
+++ b/modules/help-utils.el
@@ -55,6 +55,7 @@
 
 (defun cj/local-arch-wiki-search ()
   "Prompt for an ArchWiki topic and open its local HTML copy in EWW.
+
 Looks for “*.html” files under \"/usr/share/doc/arch-wiki/html/en\",
 lets you complete on their basenames, and displays the chosen file
 with `eww-browse-url'. If no file is found, reminds you to install

--- a/modules/jumper.el
+++ b/modules/jumper.el
@@ -19,6 +19,7 @@
 
 (defcustom jumper-prefix-key "M-SPC"
   "Prefix key for jumper commands.
+
 Note that using M-SPC will override the default binding to just-one-space."
   :type 'string
   :group 'jumper)

--- a/modules/local-repository.el
+++ b/modules/local-repository.el
@@ -18,16 +18,19 @@
 
 (defcustom localrepo-repository-id "localrepo"
   "The name used to identify the local repository internally.
+
 Used for the package-archive and package-archive-priorities lists.")
 
 (defcustom localrepo-repository-priority 100
   "The value for the local repository in the package-archive-priority list.
+
 A higher value means higher priority. If you want your local packages to be
 preferred, this must be a higher number than any other repositories.")
 
 (defcustom localrepo-repository-location
   (concat user-emacs-directory "/.localrepo")
   "The location of the local repository.
+
 It's a good idea to keep this with the rest of your configuration files and
 keep them in source control.")
 

--- a/modules/lorem-generator.el
+++ b/modules/lorem-generator.el
@@ -203,6 +203,7 @@
 ;;;###autoload
 (defun cj/lipsum-paragraphs (count &optional min max)
   "Insert COUNT paragraphs of lipsum.
+
 Each paragraph has a random length between MIN and MAX words.
 Defaults: MIN=30, MAX=80."
   (interactive "nNumber of paragraphs: ")
@@ -223,6 +224,7 @@ Defaults: MIN=30, MAX=80."
   (expand-file-name "latin.txt"
 					(file-name-directory (or load-file-name buffer-file-name)))
   "Default training file for cj-lipsum.
+
 This should be a plain UTF-8 text file with hundreds of Latin words
 or sentences.  By default it points to the bundled `latin.txt`."
   :type 'file

--- a/modules/mail-config.el
+++ b/modules/mail-config.el
@@ -25,6 +25,7 @@
 
 (defun cj/mu4e-mark-all-headers ()
   "Mark all headers for a later action.
+
 Prompts user for the action when executing."
   (interactive)
   (mu4e-headers-mark-for-each-if

--- a/modules/org-agenda-config.el
+++ b/modules/org-agenda-config.el
@@ -68,6 +68,7 @@
 
 (defun cj/add-files-to-org-agenda-files-list (directory)
   "Search for files named \\='todo.org\\=' add them to org-project-files.
+
 DIRECTORY is a string of the path to begin the search."
   (interactive "D")
   (setq org-agenda-files
@@ -82,6 +83,7 @@ DIRECTORY is a string of the path to begin the search."
 
 (defun cj/build-org-agenda-list ()
   "Rebuilds the org agenda list.
+
 Begins with the inbox-file and schedule-file, then searches for org-roam
 Projects and adds all todo.org files from code and project directories.
 Also includes contacts-file for birthdays/anniversaries."
@@ -101,6 +103,7 @@ Also includes contacts-file for birthdays/anniversaries."
 
 (defun cj/todo-list-all-agenda-files ()
   "Displays an \\='org-agenda\\=' todo list.
+
 The contents of the agenda will be built from org-project-files and org-roam
 files that have project in their filetag."
   (interactive)
@@ -113,6 +116,7 @@ files that have project in their filetag."
 
 (defun cj/todo-list-from-this-buffer ()
   "Displays an \\='org-agenda\\=' todo list built from the current buffer.
+
 If the current buffer isn't an org buffer, inform the user."
   (interactive)
   (if (eq major-mode 'org-mode)
@@ -144,6 +148,7 @@ If the current buffer isn't an org buffer, inform the user."
 
 (defun cj/org-skip-subtree-if-priority (priority)
   "Skip an agenda subtree if it has a priority of PRIORITY.
+
 PRIORITY may be one of the characters ?A, ?B, or ?C."
   (let ((subtree-end (save-excursion (org-end-of-subtree t)))
         (pri-value (* 1000 (- org-lowest-priority priority)))
@@ -154,6 +159,7 @@ PRIORITY may be one of the characters ?A, ?B, or ?C."
 
 (defun cj/org-skip-subtree-if-keyword (keywords)
   "Skip an agenda subtree if it has a TODO keyword in KEYWORDS.
+
 KEYWORDS must be a list of strings."
   (let ((subtree-end (save-excursion (org-end-of-subtree t))))
     (if (member (org-get-todo-state) keywords)
@@ -180,6 +186,7 @@ KEYWORDS must be a list of strings."
 
 (defun cj/main-agenda-display ()
   "Display the main daily org-agenda view.
+
 This uses all org-agenda targets and presents three sections:
 - All unfinished priority A tasks
 - Today's schedule, including habits with consistency graphs
@@ -199,6 +206,7 @@ The agenda is rebuilt from all sources before display, including:
 
 (defun cj/add-timestamp-to-org-entry (s)
   "Add an event with time S to appear underneath the line-at-point.
+
 This allows a line to show in an agenda without being scheduled or a deadline."
   (interactive "sTime: ")
   (defvar cj/timeformat "%Y-%m-%d %a")

--- a/modules/org-babel-config.el
+++ b/modules/org-babel-config.el
@@ -29,8 +29,10 @@
 ;; org-babel verifies before each execution
 
 (defun babel-confirm (flag)
-  "Report the setting of org-confirm-babel-evaluate.
-   If invoked with C-u, toggle the setting."
+  "Report the setting of `org-confirm-babel-evaluate'.
+
+If invoked with \[universal-argument], toggle the setting based on FLAG.
+FLAG is the raw prefix argument passed interactively."
   (interactive "P")
   (if (equal flag '(4))
       (setq org-confirm-babel-evaluate (not org-confirm-babel-evaluate)))

--- a/modules/org-capture-config.el
+++ b/modules/org-capture-config.el
@@ -20,12 +20,14 @@
 ;; ---------------------------- Org Webpage Clipper ----------------------------
 ;; Allows saving a copy of the page eww is visiting for offline reading.
 ;; In other words, it's a "Pocket/Instapaper" that keeps the article in Emacs.
+
 ;; Used in conjuction with org-capture-template "w" "Web Page Clipper" below.
 
 
 (defun cj/org-webpage-clipper ()
-  "Capture a web page for later viewing in an org-file.
-  and Returns the yanked content as a string."
+  "Capture the current web page for later viewing in an Org file.
+
+Return the yanked content as a string so templates can insert it."
   (interactive)
   (let* ((source-buffer (org-capture-get :original-buffer))
 		 (source-mode (with-current-buffer source-buffer major-mode)))
@@ -46,6 +48,7 @@
 
 (defun cj/org-capture-pdf-active-region ()
   "Capture the active region of the pdf-view buffer.
+
 Intended to be called within an org capture template."
   (let* ((pdf-buf-name (plist-get org-capture-plist :original-buffer))
          (pdf-buf (get-buffer pdf-buf-name)))

--- a/modules/org-config.el
+++ b/modules/org-config.el
@@ -13,6 +13,7 @@
 (defvar org-archive-location
   (concat sync-dir "/archives/archive.org::datetree/")
   "Location of the archive file.
+
 The archive file is where org entries that are archived via
 org-archive-subtree-default are placed.")
 

--- a/modules/org-noter-config.el
+++ b/modules/org-noter-config.el
@@ -52,6 +52,7 @@
 
 (defun cj/org-noter-check-document-path ()
   "Check if the document path in the current heading exists.
+
 This is just a temporary debug function."
   (interactive)
   (let ((doc-path (org-entry-get nil "NOTER_DOCUMENT" t)))

--- a/modules/org-refile-config.el
+++ b/modules/org-refile-config.el
@@ -42,6 +42,7 @@
 
 (defun cj/org-refile (&optional ARG DEFAULT-BUFFER RFLOC MSG)
   "Simply rebuilds the refile targets before calling org-refile.
+
 ARG DEFAULT-BUFFER RFLOC and MSG parameters passed to org-refile."
   (interactive "P")
   (cj/build-org-refile-targets)

--- a/modules/org-roam-config.el
+++ b/modules/org-roam-config.el
@@ -86,6 +86,7 @@
 
 (defun cj/org-roam-node-insert-immediate (arg &rest args)
   "Create new node and insert its link immediately.
+
 This is mainly a wrapper around org-roam-node-insert to achieve immediate finish
 to the capture. The prefix ARG and ARGS are the filter function and the rest of
 the arguments that org-roam-node-insert expects."
@@ -112,6 +113,7 @@ the arguments that org-roam-node-insert expects."
 
 (defun cj/org-roam-find-node (tag template-key template-file &optional subdir)
   "List all nodes of type \='TAG\=' in completing read for selection or creation.
+
 Interactively find or create an Org-roam node with a given \='TAG\='. Newly
 created nodes are added to the agenda and follow a template defined by
 \='TEMPLATE-KEY\=' and \='TEMPLATE-FILE\='."

--- a/modules/prog-general.el
+++ b/modules/prog-general.el
@@ -83,6 +83,7 @@
   :config
   (defun cj/find-project-root-file (regexp)
 	"Return first file in the current Projectile project root matching REGEXP.
+
 Match is done against (downcase file) for case-insensitivity.
 REGEXP must be a string or an rx form."
 	(when-let ((root (projectile-project-root)))
@@ -95,6 +96,7 @@ REGEXP must be a string or an rx form."
 
   (defun cj/open-project-root-todo ()
 	"Open todo.org in the current Projectile project root.
+
 If no such file exists there, display a message."
 	(interactive)
 	(if-let ((root (projectile-project-root)))

--- a/modules/show-kill-ring.el
+++ b/modules/show-kill-ring.el
@@ -16,6 +16,7 @@
 
 (defvar show-kill-max-item-size 1000
   "This represents the size of a \='kill ring\=' entry.
+
 A positive number means to limit the display of \='kill-ring\=' items to
 that number of characters.")
 
@@ -26,6 +27,7 @@ that number of characters.")
 
 (defun show-kill-ring ()
   "Show the current contents of the kill ring in a separate buffer.
+
 This makes it easy to figure out which prefix to pass to yank."
   (interactive)
   ;; kill existing one, since erasing it doesn't work
@@ -77,6 +79,7 @@ This makes it easy to figure out which prefix to pass to yank."
 
 (defun show-kill-insert-item (item)
   "Insert an ITEM from the kill ring into the current buffer.
+
 If it's too long, truncate it first."
   (let ((max show-kill-max-item-size))
 	(cond

--- a/modules/system-defaults.el
+++ b/modules/system-defaults.el
@@ -24,6 +24,7 @@
 
 (defun cj/log-comp-warning (type message &rest args)
   "Log native-comp warnings of TYPE with MESSAGE & ARGS to 'comp-warnings-log'.
+
 Suppress them from appearing in the *Warnings* buffer. If TYPE contains 'comp',
 log the warning with a timestamp to the file specified by 'comp-warnings-log'.
 Return non-nil to indicate the warning was handled."
@@ -58,6 +59,7 @@ Return non-nil to indicate the warning was handled."
 
 (defun cj/disabled ()
   "Do absolutely nothing and do it quickly.
+
 Used to disable functionality with defalias 'somefunc 'cj/disabled)."
   (interactive))
 

--- a/modules/system-utils.el
+++ b/modules/system-utils.el
@@ -19,6 +19,7 @@
 
 (defun cj/open-file-with-command (command)
   "Open the current file with COMMAND.
+
 Works in both Dired buffers and regular file buffers. The command runs
 fully detached from Emacs."
   (interactive "MOpen with command: ")

--- a/modules/test-runner.el
+++ b/modules/test-runner.el
@@ -18,10 +18,12 @@
 
 (defvar cj/test-focused-files '()
   "List of test files for focused test execution.
+
 Each element is a filename (without path) to run.")
 
 (defvar cj/test-mode 'all
   "Current test execution mode.
+
 Either 'all (run all tests) or 'focused (run only focused tests).")
 
 (defvar cj/test-last-results nil
@@ -102,6 +104,7 @@ Either 'all (run all tests) or 'focused (run only focused tests).")
 
 (defun cj/test--extract-test-names (file)
   "Extract test names from FILE.
+
 Returns a list of test name symbols defined in the file."
   (let ((test-names '()))
 	(with-temp-buffer

--- a/modules/ui-config.el
+++ b/modules/ui-config.el
@@ -36,6 +36,7 @@
 
 (defcustom cj/transparency-level 84
   "Opacity level for Emacs frames when `cj/enable-transparency' is non-nil.
+
 100 = fully opaque, 0 = fully transparent."
   :type 'integer
   :group 'ui-config)
@@ -64,6 +65,7 @@
 
 (defun cj/apply-transparency ()
   "Apply `cj/transparency-level' to the selected frame and future frames.
+
 When `cj/enable-transparency' is nil, reset alpha to fully opaque."
   (let ((alpha (if cj/enable-transparency
 				   (cons cj/transparency-level cj/transparency-level)

--- a/modules/ui-navigation.el
+++ b/modules/ui-navigation.el
@@ -70,9 +70,10 @@
 ;; ------------------------- Split Window Reorientation ------------------------
 
 (defun toggle-window-split ()
-  "Toggle the orientation fo the window split.
-If the window is split horizontally, change the split to be vertical.
-If it's vertical, change the split to be to horizontal.
+  "Toggle the orientation of the current window split.
+
+If the window is split horizontally, change the split to vertical.
+If it's vertical, change the split to horizontal.
 This function won't work with more than one split window."
   (interactive)
   (if (= (count-windows) 2)

--- a/modules/ui-theme.el
+++ b/modules/ui-theme.el
@@ -32,6 +32,7 @@
 
 (defun cj/switch-themes ()
   "Function to switch themes and save chosen theme name for persistence.
+
 Unloads any other applied themes before applying the chosen theme."
   (interactive)
   (let ((chosentheme ""))
@@ -50,17 +51,20 @@ Unloads any other applied themes before applying the chosen theme."
 
 (defvar theme-file (concat sync-dir "emacs-theme.persist")
   "The location of the file to persist the theme name.
+
 If you want your theme change to persist across instances, put this in a
 directory that is sync'd across machines with this configuration.")
 
 (defvar fallback-theme-name "modus-vivendi"
   "The name of the theme to fallback on.
+
 This is used then there's no file, or the theme name doesn't match
 any of the installed themes. This should be a built-in theme. If theme name is
 'nil', there will be no theme.")
 
 (defun cj/read-file-contents (filename)
   "Read FILENAME and return its content as a string.
+
 If FILENAME isn't readable, return nil."
   (when (file-readable-p filename)
     (with-temp-buffer
@@ -69,6 +73,7 @@ If FILENAME isn't readable, return nil."
 
 (defun cj/write-file-contents (content filename)
   "Write CONTENT to FILENAME.
+
 If FILENAME isn't writeable, return nil. If successful, return t."
   (when (file-writable-p filename)
     (condition-case err
@@ -83,6 +88,7 @@ If FILENAME isn't writeable, return nil. If successful, return t."
 
 (defun cj/get-active-theme-name ()
   "Return the name of the active UI theme as a string.
+
 Returns fallback-theme-name if no theme is active."
   (if custom-enabled-themes
       (symbol-name (car custom-enabled-themes))
@@ -96,12 +102,14 @@ Returns fallback-theme-name if no theme is active."
 
 (defun cj/load-fallback-theme (msg)
   "Display MSG and load ui-theme fallback-theme-name.
+
 Used to handle errors with loading persisted theme."
   (message "%s Loading fallback theme %s" msg fallback-theme-name)
   (load-theme (intern fallback-theme-name) t))
 
 (defun cj/load-theme-from-file ()
   "Apply the theme name contained in theme-file as the active UI theme.
+
 If the theme is nil, it disables all current themes. If an error occurs
 loading the file name, the fallback-theme-name is applied and saved."
   (let ((theme-name (cj/read-file-contents theme-file)))

--- a/modules/undead-buffers.el
+++ b/modules/undead-buffers.el
@@ -4,7 +4,6 @@
 ;;
 ;; This library allows for “burying” selected buffers instead of killing them.
 ;; Since they won't be killed, I'm calling them "undead buffers".
-;;
 ;; The main function cj/kill-buffer-or-bury-alive replaces kill-buffer.
 ;;
 ;; Additional helper commands and key bindings:

--- a/modules/user-constants.el
+++ b/modules/user-constants.el
@@ -120,6 +120,7 @@
 
 (defvar webclipped-file (expand-file-name "webclipped.org" sync-dir)
   "The location of the org file that keeps webclips to read.
+
 For more information, see org webclipper section of org-capture-config.el")
 
 ;; ------------------------- Verify Or Create Functions ------------------------
@@ -149,6 +150,7 @@ For more information, see org webclipper section of org-capture-config.el")
 
 (defun cj/initialize-user-directories-and-files ()
   "Initialize all necessary directories and files.
+
 This ensures that all directories and files required by the Emacs configuration
 exist, creating them if necessary. This makes the configuration more robust
 and portable across different machines."

--- a/modules/video-audio-recording.el
+++ b/modules/video-audio-recording.el
@@ -28,12 +28,14 @@
 
 (defcustom cj/recording-mic-boost 2.0
   "Volume multiplier for microphone in recordings.
+
 1.0 = normal volume, 2.0 = double volume (+6dB), 0.5 = half volume (-6dB)."
   :type 'number
   :group 'cj-recording)
 
 (defcustom cj/recording-system-volume 0.5
   "Volume multiplier for system audio in recordings.
+
 1.0 = normal volume, 2.0 = double volume (+6dB), 0.5 = half volume (-6dB)."
   :type 'number
   :group 'cj-recording)
@@ -46,6 +48,7 @@
 
 (defun cj/video-recording-start (arg)
   "Starts the ffmpeg video recording.
+
 If called with a prefix arg C-u, choose the location on where to save the
 recording, otherwise use the default location in =video-recordings-dir'."
   (interactive "P")
@@ -59,6 +62,7 @@ recording, otherwise use the default location in =video-recordings-dir'."
 
 (defun cj/audio-recording-start (arg)
   "Starts the ffmpeg audio recording.
+
 If called with a prefix arg C-u, choose the location on where to save the
 recording, otherwise use the default location in =video-recordings-dir'."
   (interactive "P")

--- a/modules/wip.el
+++ b/modules/wip.el
@@ -147,10 +147,12 @@
         (define-key map (kbd (format "<%s%s>" pref evt)) #'ignore)))
     map)
   "Keymap for `mouse-trap-mode'. Unbinds almost every mouse event.
+
 Disabling mouse prevents accidental mouse moves modifying text.")
 
 (define-minor-mode mouse-trap-mode
   "Globally disable most mouse and trackpad events.
+
 When active, <mouse-*>, <down-mouse-*>, <drag-mouse-*>,
 <double-mouse-*>, <triple-mouse-*>, and wheel events are bound to `ignore',
 with or without C-, M-, S- modifiers."


### PR DESCRIPTION
## Summary
- rewrite GPTel helper docstrings to explain backend management, autosave flags, and interaction prompts
- normalize custom utility docstrings so regional operations, keymaps, and editing commands describe their arguments and effects
- clarify configuration docstrings throughout the modules directory for integrations like Dirvish, Elfeed, and media recording

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf8998d03c83238a82a357b9785889