### PR TITLE
Document workflows in module commentary

### DIFF
--- a/modules/elfeed-config.el
+++ b/modules/elfeed-config.el
@@ -2,7 +2,15 @@
 ;; author Craig Jennings <c@cjennings.net>
 ;;
 ;;; Commentary:
+;; Launch Elfeed with M-R to update feeds and focus the newest entry right away.
+;; Inside the search buffer:
+;; - Use v to stream via the default player, d to download, w/b to open via EWW or browser.
+;; - Hit V to pick a different player for future launches.
+;; - Use R/U to mark all visible stories read or unread before narrowing again.
 ;;
+;; When a video needs streaming credentials the player selection drives yt-dlp format choices;
+;; use `cj/select-media-player` to swap profiles, or customize `cj/media-players` for your system.
+;; All commands assume yt-dlp and your players live on PATH.
 ;;
 ;;; Code:
 

--- a/modules/org-noter-config.el
+++ b/modules/org-noter-config.el
@@ -1,7 +1,10 @@
 ;;; org-noter-config.el ---  -*- coding: utf-8; lexical-binding: t; -*-
 
 ;;; Commentary:
-;;
+;; Open a PDF or DjVu file, hit F6, and org-noter splits the frame with notes beside the document.
+;; Notes live under ~/sync/org-noter/reading-notes.org by default; adjust the path when prompted the first time.
+;; Use org-noter capture keys while annotating—`C-c n c` checks linked documents, and `C-c n u` rewrites stale paths after moving files.
+;; Sessions resume where you stopped thanks to automatic location saves.
 
 ;;; Code:
 

--- a/modules/prog-shell.el
+++ b/modules/prog-shell.el
@@ -2,7 +2,8 @@
 ;; author Craig Jennings <c@cjennings.net>
 
 ;;; Commentary:
-;;
+;; Open any *.sh buffer and sh-mode loads with Flycheck attached, so syntax errors appear immediately.
+;; Re-save or invoke C-c ! l to refresh diagnostics while you iterate on scripts.
 
 ;;; Code:
 

--- a/modules/prog-training.el
+++ b/modules/prog-training.el
@@ -1,7 +1,9 @@
 ;;; prog-training.el --- Training -*- lexical-binding: t; coding: utf-8; -*-
 ;; author: Craig Jennings <c@cjennings.net>
 ;;; Commentary:
-;;
+;; Use C-h E to launch Exercism when you want to fetch or submit practice problems.
+;; Use C-h L for LeetCode sessions; the package drops solved files under ~/code/leetcode in Go format.
+;; Both bindings autoload their packages, so invoking the key is the whole workflow.
 
 ;;; Code:
 

--- a/modules/prog-webdev.el
+++ b/modules/prog-webdev.el
@@ -1,7 +1,15 @@
 ;;; prog-webdev.el --- Web Development Packages and Settings -*- lexical-binding: t; coding: utf-8; -*-
 ;; author: Craig Jennings <c@cjennings.net>
 ;;; Commentary:
+;; Open a project file and Emacs selects the right helper:
+;; - *.json buffers drop into json-mode for quick structural edits.
+;; - *.js buffers jump into js2-mode for linty feedback.
+;; - Mixed HTML templates land in web-mode which chains Tide and CSS Eldoc.
 ;;
+;; Workflow:
+;; - Hit C-RET in web-mode to ask for completions; the command routes to Tide, company-css, or dabbrev based on the language at point.
+;; - Eldoc messages come from `cj/eldoc-web-mode`, so keeping point over JS, CSS, or markup swaps the doc source automatically.
+;; - New web buffers call `cj/setup-web-mode-mixed`, enabling Tide so goto-definition and rename are ready without extra setup.
 
 ;;; Code:
 

--- a/modules/system-defaults.el
+++ b/modules/system-defaults.el
@@ -2,9 +2,14 @@
 ;; author: Craig Jennings <c@cjennings.net>
 ;;
 ;;; Commentary:
-;;
-;;
-;;
+;; Loads during init to set sane defaults: UTF-8 everywhere, quiet prompts, synced clipboards,
+;; and hands-off async shell buffers. Nothing to call—just launch Emacs and the environment is ready.
+;; Native compilation is tuned for performance and its warnings get logged to comp-warnings.log.
+
+;;; Implementation Notes:
+;; `cj/log-comp-warning` advices `display-warning` so native-comp notices land in the log instead of popping Messages.
+;; Remove the advice if you need stock warning buffers for debugging.
+
 ;;; Code:
 
 ;; -------------------------- Native Comp Preferences --------------------------

--- a/modules/weather-config.el
+++ b/modules/weather-config.el
@@ -1,7 +1,9 @@
 ;;; weather-config.el ---  -*- lexical-binding: t; coding: utf-8; -*-
 ;; author: Craig Jennings <c@cjennings.net>
 ;;; Commentary:
-;;
+;; Call M-W to open wttrin with your preferred location list immediately.
+;; Adjust the city list by editing `wttrin-default-locations` or answering wttrin prompts when asked.
+;; Forecasts arrive in an Emacs buffer, so you can stay keyboard-only while checking weather.
 
 ;;; Code:
 


### PR DESCRIPTION
## Summary
- add workflow-oriented commentary to the web, shell, training, weather, org-noter, elfeed, and system defaults modules

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d03e7b6a288323b886fab46044d3c1